### PR TITLE
Convert some &Vec<T> into &[T] slices.

### DIFF
--- a/src/statemap.rs
+++ b/src/statemap.rs
@@ -536,7 +536,7 @@ impl StatemapEntity {
 
     fn output_svg(&self, config: &StatemapSVGConfig,
         globals: &StatemapSVGGlobals,
-        colors: &Vec<StatemapColor>, y: u32) -> Vec<String>
+        colors: &[StatemapColor], y: u32) -> Vec<String>
     {
         let rect_width = |rect: &StatemapRect| -> f64 {
             /*
@@ -1442,7 +1442,7 @@ impl Statemap {
             println!("</svg>");
         };
 
-        let output_legend = |props: &Props, colors: &Vec<StatemapColor>| {
+        let output_legend = |props: &Props, colors: &[StatemapColor]| {
             let x = props.x;
             let mut y = props.y;
             let height = props.lheight;


### PR DESCRIPTION
It is convention in Rust that when you need to pass around a constant reference to a Vec, you should instead pass around a slice of T, which is functionally equivalent.

This has the benefit that if, in the future, you decide to get that "array" of data from another source (like a stack allocated array, for instance), you can use the same data structures and functions that require the slice, even if the memory isn't owned by a Vec.

It effectively gives your data structures and functions the freedom to not care about how the data is owned, and merely realise that it is borrowed.