### PR TITLE
Use pattern matching to avoid unwraps when creating color

### DIFF
--- a/src/statemap.rs
+++ b/src/statemap.rs
@@ -232,8 +232,8 @@ impl FromStr for StatemapColor {
             let g = u8::from_str_radix(&name[3..5], 16);
             let b = u8::from_str_radix(&name[5..7], 16);
 
-            if r.is_ok() && g.is_ok() && b.is_ok() {
-                let rgb = Srgb::new(r.unwrap(), g.unwrap(), b.unwrap());
+            if let (Ok(r), Ok(g), Ok(b)) = (r, g, b) {
+                let rgb = Srgb::new(r, g, b);
 
                 return Ok(StatemapColor {
                     color: rgb.into_format().into_linear().into()


### PR DESCRIPTION
By using pattern matching, we can avoid calling the unwrap methods, thus giving us more confidence the program isn't going to needlessly panic. (It wasn't going to anyway, due to the checking but this is less noisy.)