### PR TITLE
Defeat the borrow checker in entity lookup

### DIFF
--- a/src/statemap.rs
+++ b/src/statemap.rs
@@ -810,18 +810,14 @@ impl Statemap {
          * The lack of non-lexical lifetimes causes this code to be a bit
          * gnarlier than it should really have to be.
          */
-        if self.entities.contains_key(name) {
-            return match self.entities.get_mut(name) {
-                Some(entity) => { entity },
-                None => unreachable!()
-            };
-        }
+        let byid = &mut self.byid;
+        let entities = &mut self.entities;
 
-        let entity = StatemapEntity::new(name, self.byid.len());
-        self.byid.push(name.to_string());
-
-        self.entities.insert(name.to_string(), entity);
-        self.entities.get_mut(name).unwrap()
+        entities.entry(name.to_string()).or_insert_with(|| {
+            let entity = StatemapEntity::new(name, byid.len());
+            byid.push(name.to_string());
+            entity
+        })
     }
 
     /*


### PR DESCRIPTION
Through the power of friendship and the Entry API.

One bit that's debatable is this allocates a key even if the entry is present...