### PR TITLE
Cut parse time almost in half

### DIFF
--- a/src/statemap.rs
+++ b/src/statemap.rs
@@ -21,7 +21,8 @@ struct StatemapInputState {
 
 #[derive(Deserialize, Debug)]
 struct StatemapInputDatum {
-    time: String,                           // time of this datum
+    #[serde(deserialize_with = "datum_time_from_string")]
+    time: u64,                              // time of this datum
     entity: String,                         // name of entity
     state: u32,                             // state entity is in at time
 }
@@ -1062,13 +1063,8 @@ impl Statemap {
         match try_parse::<StatemapInputDatum>(payload) {
             Ok(None) => return Ok(Ingest::EndOfFile),
             Ok(Some(datum)) => { 
-                let time: u64;
+                let time: u64 = datum.time;
                 let nstates: u32 = self.states.len() as u32;
-
-                match <u64>::from_str(&datum.time) {
-                    Ok(t) => time = t,
-                    _ => return self.err("illegal time value")
-                }
 
                 /*
                  * If the time of this datum is after our specified end time,
@@ -1580,6 +1576,21 @@ where
 
 fn count_newlines(bytes: &[u8]) -> usize {
     bytes.iter().filter(|&&b| b == b'\n').count()
+}
+
+/*
+ * The time value is written in the input as a JSON string containing a number.
+ * Deserialize just the number here without allocating memory for a String.
+ */
+fn datum_time_from_string<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s: &str = serde::Deserialize::deserialize(deserializer)?;
+    match u64::from_str(s) {
+        Ok(time) => Ok(time),
+        Err(_) => Err(serde::de::Error::custom("illegal time value")),
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I used the following program to generate a 1.6 gigabyte sample input that resembles what you show in your [presentation](https://www.youtube.com/watch?v=aWbGPMxs0AM). Hopefully this is sufficiently representative to perform useful optimizations as far as parsing. In the presentation it looked like these `StatemapInputDatum` values make up the bulk of the data.

```rust
for i in 0..30000000 {
    let t = 20000000000u64 + i;
    let e = 50000 + i % 1000;
    let s = i % 3;
    println!(r#"{{ "time": "{}", "entity": "{}", "state": {} }}"#, t, e, s);
}
```

----

###### First commit
### Remove homegrown JSON lexing code
    
Much of the ingest time is being spent in your `json_start` and `json_end` functions, not in serde_json. I replaced those with using [`serde_json::StreamDeserializer`](https://docs.serde.rs/serde_json/struct.StreamDeserializer.html) to read one JSON element at a time without computing length in advance.

On my sample input this commit drops parse time from 10.1 seconds to 6.8 seconds. I isolated parse time by inserting an early return just below the match statement that contains the `"illegal time value"` error.

---

##### Second commit
### Avoid allocating String for datum time

A huge amount of the parse time is spent allocating Strings. The string associated with the time of each datum is never used as a string but just parsed to a u64. This commit avoids allocating those as strings in the first place.

On my sample input this commit drops parse time from 6.8 seconds to 5.7 seconds. I isolated parse time by inserting an early return just below the line that contains `let nstates: u32`.

---